### PR TITLE
codeToSession 增加自定义 header 参数.

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -47,6 +47,8 @@ export interface IInitOption {
 export interface ICodeToSessionOptions{
     /* CGI的url */
     url: string;
+    /* 增加自定义 header */
+    header?: IAnyObject;
     /* 调用该CGI的方法 */
     method?: 'OPTIONS'
         | 'GET'

--- a/src/module/sessionManager.ts
+++ b/src/module/sessionManager.ts
@@ -144,6 +144,7 @@ function code2Session(code: string) {
         let start = new Date().getTime();
         wx.request({
             url: requestHandler.format(config.codeToSession.url),
+            header: config.codeToSession.header || {"content-type": "application/json"},
             data,
             method: config.codeToSession.method || 'GET',
             success(res: wx.RequestSuccessCallbackResult) {


### PR DESCRIPTION
小程序向后端 POST 数据的时候，有些语言会接收不到参数，原因是小程序编辑器默认的 content-type 为 application/json，修改为 application/x-www-form-urlencoded 没问题，所以给 codeToSession 增加了 header 参数。