### PR TITLE
fix: 修复某些并发场景下，异步delSession后，某些请求sid和jscode都为空的问题

### DIFF
--- a/src/module/requestHandler.ts
+++ b/src/module/requestHandler.ts
@@ -147,11 +147,18 @@ function getGlobalData() {
 }
 
 function doRequest(obj: IRequestOption) {
-    obj = initializeRequestObj(obj);
-    if (obj.reLoginCount === 0 && typeof config.beforeSend === "function") {
-        obj = config.beforeSend(obj, status.session);
-    }
-    return new Promise<WechatMiniprogram.RequestSuccessCallbackResult>((resolve, reject) => {
+    return new Promise<WechatMiniprogram.RequestSuccessCallbackResult>(async (resolve, reject) => {
+        // 由于真正发请求时经过了异步处理流程，中途可能存在session被清除的情况，需要再次checkLogin
+        try {
+            await sessionManager.checkLogin();
+        } catch (error) {
+            return reject(error);
+        }
+    
+        obj = initializeRequestObj(obj);
+        if (obj.reLoginCount === 0 && typeof config.beforeSend === "function") {
+            obj = config.beforeSend(obj, status.session);
+        }
         wx.request({
             ...obj,
             success(res) {

--- a/src/module/sessionManager.ts
+++ b/src/module/sessionManager.ts
@@ -254,5 +254,6 @@ function main(relatedRequestObj?: IRequestOption | IUploadFileOption) {
 export default {
     main,
     setSession,
-    delSession
+    delSession,
+    checkLogin
 }


### PR DESCRIPTION
# 修复前
## 异常路径
1）本地无sid，checkLogin触发登陆，延迟delSesion无影响：
<img width="603" alt="企业微信截图_0650ae8d-232b-4717-8f4c-ff64ae136adf" src="https://github.com/IvinWu/weRequest/assets/42300381/5aae3d5f-3aaa-4fd5-ae9a-ca48f2eea6d2">
2）本地有sid，延迟delSession，请求池中的请求可能会缺失sid和jscode：
<img width="635" alt="企业微信截图_4df63fd9-bd28-44a3-941a-c81291efd97e" src="https://github.com/IvinWu/weRequest/assets/42300381/28e14877-6a30-4adb-8331-3f68b1bf2c79">

# 修复后
## 异常路径
1）无sid，正常登录，延迟delSession无影响：
<img width="634" alt="企业微信截图_e55afd09-71a6-4f28-ab1d-e9d77c773f74" src="https://github.com/IvinWu/weRequest/assets/42300381/8df6d505-a40b-48d1-8022-faf8c9022915">
2）有sid，延迟delSession，login成功，无影响：
<img width="628" alt="企业微信截图_9fbf78fc-c700-4ccd-8393-235d0792470f" src="https://github.com/IvinWu/weRequest/assets/42300381/678ad78d-a9db-4230-881d-23ead3746182">
3）有sid，延迟delSession，模拟login失败，触发errorCallback：
<img width="959" alt="企业微信截图_f45121eb-9ae5-42bc-bb84-5322f3f36bb5" src="https://github.com/IvinWu/weRequest/assets/42300381/ed5f3513-3fea-46fa-9739-b0b9722c75b5">

## 正常路径
1）无sid可正常登录
<img width="602" alt="企业微信截图_66657d92-5645-4f01-acf0-f8cbdddb0111" src="https://github.com/IvinWu/weRequest/assets/42300381/2b9fb64a-f4ce-483d-89a5-ad3068c21efb">
2）sid失效可正常登录
<img width="637" alt="企业微信截图_b367504d-5f34-4e1e-9179-29a79670093f" src="https://github.com/IvinWu/weRequest/assets/42300381/4cc7f1ca-60a6-4547-ad77-502bef954d5d">



